### PR TITLE
Add DevLess (BaaS platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Company | Openness Pledge | Open Product | Open Standards | Statement | Open Cha
 ![OpenCraft](http://www.google.com/s2/favicons?domain=opencraft.com) [**OpenCraft**](http://opencraft.com/) | [OpenCraft \| Open edX Development &amp; Hosting Services](http://opencraft.com/) | N/A |  |  |  |
 ![Red Hat](http://www.google.com/s2/favicons?domain=redhat.com) [**Red Hat**](https://www.redhat.com/) | [Red Hat Jobs - Our culture](https://www.redhat.com/en/jobs/life/culture) | [Mics](https://www.redhat.com/en/open-source/communities) |  |  |  |
 ![Tessel](http://i.imgur.com/Xe9AYlw.png) [**Tessel**](https://tessel.io/) | [Open Source - Tessel](https://tessel.io/opensource) | :octocat:[Tessel](https://github.com/tessel/project) |  |  |  |
+![DevLess](https://www.google.com/s2/favicons?domain=devless.io) [**DevLess**](https://devless.io/) | [Open Source - DevLess](https://devless.io) | :octocat:[DevLess](https://github.com/DevlessTeam/DV-PHP-CORE) |  |  |  |
 
 ## Resources
 


### PR DESCRIPTION
DevLess is a platform that allows you to easily build robust backends for your web and mobile applications by piecing together plug and play backend modules.
It is a pretty young company about 6 months old.